### PR TITLE
only restart nginx if it's running

### DIFF
--- a/restart-nginx.sh
+++ b/restart-nginx.sh
@@ -6,5 +6,7 @@ NC='\033[0m' # no colour - reset console colour
 
 echo -e "${YELLOW}Restarting nginx. This requires sudo access.${NC}"
 
-sudo nginx -s stop
+if pgrep 'nginx' > /dev/null; then
+  sudo nginx -s stop
+fi
 sudo nginx


### PR DESCRIPTION
removes a pid not found error when running `sudo nginx -s stop` and nginx is not running.