### PR TITLE
use the full path when executing a sibling script

### DIFF
--- a/setup-app.rb
+++ b/setup-app.rb
@@ -4,12 +4,14 @@ require 'yaml'
 require 'fileutils'
 
 if ARGV.size != 1
-    puts "usage: setup-app.rb <config.yml>"
+    puts "usage: #{File.basename(__FILE__)} /path/to/nginx-mapping.yaml"
     exit(1)
 end
 
+HERE=File.dirname(__FILE__)
+
 DEFAULT_DOMAIN_ROOT = "local.dev-gutools.co.uk"
-NGINX_DIR = `./locate-nginx.sh`.chomp
+NGINX_DIR = `#{HERE}/locate-nginx.sh`.chomp
 
 config_file = ARGV[0]
 
@@ -105,11 +107,11 @@ server {
 EOS
         end
         if ssl
-          `./setup-certs.sh #{domain}`
+          `#{HERE}/setup-certs.sh #{domain}`
         end
     end
 end
 
 puts "Restarting nginx. This needs sudo permission, please enter password when prompted."
-`./restart-nginx.sh`
+`#{HERE}/restart-nginx.sh`
 puts "Done."

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -31,7 +31,9 @@ if mac && installed java; then
   export JAVA_HOME=$(/usr/libexec/java_home)
 fi
 
-NGINX_HOME=$(./locate-nginx.sh)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+NGINX_HOME=$("${DIR}/locate-nginx.sh")
 CERT_DIRECTORY=$HOME/.gu/mkcert
 
 DOMAIN=$1


### PR DESCRIPTION
This is to make it easier to craft a brew formula as its currently failing like this:

```bash
$ dev-nginx-app ~/code/grid/nginx-mappings.yml
/usr/local/bin/dev-nginx-app:12:in ``': No such file or directory - ./locate-nginx.sh (Errno::ENOENT)
	from /usr/local/bin/dev-nginx-app:12:in `<main>'
```