### PR TITLE
add common scripts used elsewhere for DRYness

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ $ dev-nginx
 
 dev-nginx COMMAND <OPTIONS>
 Available commands:
+- add-to-hosts-file
+- link-config
 - locate-nginx
 - restart-nginx
 - setup-app
@@ -50,6 +52,22 @@ Available commands:
 ```
 
 ### Commands
+#### `add-to-hosts-file`
+```bash
+dev-nginx add-to-hosts-file
+```
+
+If it does not already exist, adds an entry to `/etc/hosts` that resolves to `127.0.0.1`.
+
+
+#### `link-config`
+```bash
+dev-nginx link-config /path/to/site.conf
+```
+
+Symlink an existing file into nginx configuration. You'll need to restart nginx to activate it (`dev-nginx restart-nginx`).
+
+
 #### `locate-nginx`
 ```bash
 dev-nginx locate-nginx

--- a/bin/dev-nginx
+++ b/bin/dev-nginx
@@ -37,5 +37,6 @@ if [[ -f "${SCRIPT}" ]]; then
 else
   echo "dev-nginx ${SCRIPT_NAME} not recognised"
   availableCommands
+  echo "Try updating dev-nginx and retrying."
   exit 1
 fi

--- a/script/add-to-hosts-file
+++ b/script/add-to-hosts-file
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# colours
+YELLOW='\033[1;33m'
+NC='\033[0m' # no colour - reset console colour
+
+if [[ $# -lt 1 ]]
+then
+  echo "add-to-hosts-file <DOMAIN>"
+  echo "Add an entry to hosts file to resolve to 127.0.0.1"
+	echo "Example: add-to-hosts-file foo.local"
+	exit 1
+fi
+
+DOMAIN=$1
+
+if grep '127.0.0.1' /etc/hosts | grep ${DOMAIN} ; then
+  echo -e "✅ /etc/hosts entry already exists for ${DOMAIN}"
+else
+  echo -e "🔧 ${YELLOW}adding /etc/hosts entry for ${DOMAIN}. Requires sudo - enter password when prompted.${NC}"
+  sudo sh -c "echo '127.0.0.1		${DOMAIN}' >> /etc/hosts"
+fi

--- a/script/link-config
+++ b/script/link-config
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# colours
+YELLOW='\033[1;33m'
+NC='\033[0m' # no colour - reset console colour
+
+if [[ $# -lt 1 ]]
+then
+  echo "link-config /path/to/file.conf"
+  echo "symlink an nginx config file and restarts nginx"
+	exit 1
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+NGINX_HOME=$("${DIR}/locate-nginx")
+
+FILE=$1
+
+if [[ ! -f ${FILE} ]]; then
+    echo "File $FILE not found"
+    exit 1
+else
+  ln -fs ${FILE} ${NGINX_HOME}/servers/$(basename "$FILE")
+fi


### PR DESCRIPTION
- In [frontend](https://github.com/guardian/frontend/pull/21497) and support-frontend we have instructions to update the hosts file - add a script to orchestrate that.
- Some projects have a custom site config that's different from the one generated by setup-app - add a script to symlink an existing file and restart nginx.