### PR TITLE
remove file from sites-enabled if exists

### DIFF
--- a/script/link-config
+++ b/script/link-config
@@ -24,3 +24,10 @@ if [[ ! -f ${FILE} ]]; then
 else
   ln -fs ${FILE} ${NGINX_HOME}/servers/$(basename "$FILE")
 fi
+
+# remove file (or symlink) from legacy `sites-enabled` directory if it exists
+MAYBE_OLD_FILE=${NGINX_HOME}/sites-enabled/$(basename "$FILE")
+
+if [[ -f "$MAYBE_OLD_FILE" ]] || [[ -L "$MAYBE_OLD_FILE" ]]; then
+  rm ${MAYBE_OLD_FILE}
+fi


### PR DESCRIPTION
dev-nginx writes files to the `servers` directory.

During a migration to dev-nginx, you may have previously been using `sites-enabled`. That is, after running `dev-nginx link-config` we're giving nginx the same config twice; once from `sites-enabled` 
 and another from `servers`.

This updates the link-config script to remove a file (or symlink) from `sites-enabled` if it exists.