### PR TITLE
sites-enabled migration script

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ dev-nginx setup-cert demo-frontend.foobar.co.uk
 
 Uses `mkcert` to issue a certificate for a domain, writing it to `~/.gu/mkcert` and symlinking it into the directory nginx is installed.
 
+#### `migrate-from-sites-enabled`
+```bash
+dev-nginx migrate-from-sites-enabled
+```
+
+In previous versions of nginx it was common to place virtual host configuration in the `sites-enabled` directory.
+More recent versions of nginx uses the `servers` directory.
+
+`migrate-from-sites-enabled` will move files from `sites-enabled` into `servers` to avoid providing nginx with duplicate config from two different directories.
+
 #### `setup-app`
 ```bash
 dev-nginx setup-app /path/to/nginx-mapping.yml

--- a/bin/dev-nginx
+++ b/bin/dev-nginx
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 SOURCE="${BASH_SOURCE[0]}"
 DIR="$( cd "$( dirname "$SOURCE" )" && pwd )"
 MAYBE_SYMLINK="$(readlink "$SOURCE")"

--- a/script/migrate-from-sites-enabled
+++ b/script/migrate-from-sites-enabled
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+NGINX_HOME=$("${DIR}/locate-nginx")
+
+OLD_DIRECTORY=${NGINX_HOME}/sites-enabled
+NEW_DIRECTORY=${NGINX_HOME}/servers
+
+for file in $OLD_DIRECTORY/*; do
+  if [[ -f "$file" ]] || [[ -L "$file" ]]; then
+    destination=$NEW_DIRECTORY/$(basename "$file")
+    echo "moving $file to $destination"
+    mv $file $destination
+  fi
+done


### PR DESCRIPTION
In previous versions of nginx it was common to place virtual host configuration in the `sites-enabled` directory and manually add an `include sites-enabled/*` directive to the nginx config.

More recent versions of nginx uses the `servers` directory by default.

`migrate-from-sites-enabled` will move files from `sites-enabled` into `servers` to avoid providing nginx with duplicate config from two different directories.

Not sure if this belongs in `dev-nginx` as a script vs a note in a README. Thoughts welcome!