### PR TITLE
refine command names

### DIFF
--- a/script/locate
+++ b/script/locate
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'

--- a/script/locate-nginx
+++ b/script/locate-nginx
@@ -1,5 +1,1 @@
-#!/usr/bin/env bash
-
-set -e
-
-nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'
+locate

--- a/script/restart
+++ b/script/restart
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+# colours
+YELLOW='\033[1;33m'
+NC='\033[0m' # no colour - reset console colour
+
+echo -e "${YELLOW}Restarting nginx. This requires sudo access.${NC}"
+
+if pgrep 'nginx' > /dev/null; then
+  sudo nginx -s stop
+fi
+sudo nginx

--- a/script/restart-nginx
+++ b/script/restart-nginx
@@ -1,14 +1,1 @@
-#!/usr/bin/env bash
-
-set -e
-
-# colours
-YELLOW='\033[1;33m'
-NC='\033[0m' # no colour - reset console colour
-
-echo -e "${YELLOW}Restarting nginx. This requires sudo access.${NC}"
-
-if pgrep 'nginx' > /dev/null; then
-  sudo nginx -s stop
-fi
-sudo nginx
+restart


### PR DESCRIPTION
`locate-nginx` and `restart-nginx` is a bit verbose; `locate` and `restart` provides a better API.

Creates symlinks for backwards compatibility as this will be a minor release.