### PR TITLE
add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ which among other things makes it possible to share cookies for the [pan-domain 
 
 Installing and running dev-nginx will start an [nginx](https://nginx.org/en/) server instance locally on your machine.
 
-This instance will use any `*.conf` files found locally within the directory `/nginx/servers` to generate a virtual server host to proxy requests to localhost. You can locate this directory with the command `dev-nginx locate-nginx`.
+This instance will use any `*.conf` files found locally within the directory `/nginx/servers` to generate a virtual server host to proxy requests to localhost. You can locate this directory with the command `dev-nginx locate`.
 
 Each project config should include http directives for proxy localhost ports and necessary SSL certificates. This is quite repetitive, so `dev-nginx` abstracts it away with the `setup-app` and `setup-cert` commands.
 
@@ -68,10 +68,11 @@ dev-nginx COMMAND <OPTIONS>
 Available commands:
 - add-to-hosts-file
 - link-config
-- locate-nginx
-- restart-nginx
+- locate
+- restart
 - setup-app
 - setup-cert
+- start
 ```
 
 ### Commands
@@ -90,20 +91,27 @@ If it does not already exist, adds an entry to `/etc/hosts` that resolves to `12
 dev-nginx link-config /path/to/site.conf
 ```
 
-Symlink an existing file into nginx configuration. You'll need to restart nginx to activate it (`dev-nginx restart-nginx`).
+Symlink an existing file into nginx configuration. You'll need to restart nginx to activate it (`dev-nginx restart`).
 
-#### `locate-nginx`
+#### `locate`
 
 ```bash
-dev-nginx locate-nginx
+dev-nginx locate
 ```
 
 Locates the directory nginx is installed.
 
-#### `restart-nginx`
+#### `start`
+```bash
+dev-nginx start
+```
+
+Starts nginx. Will fail if currently running. Add `-i` to ignore if nginx is currently running.
+
+#### `restart`
 
 ```bash
-dev-nginx restart-nginx
+dev-nginx restart
 ```
 
 Stops, if running, and starts nginx.

--- a/script/start
+++ b/script/start
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+# colours
+YELLOW='\033[1;33m'
+NC='\033[0m' # no colour - reset console colour
+
+IGNORE_IF_ALREADY_RUNNING=false
+
+while test $# -gt 0; do
+  case "$1" in
+    -i|--ignore-if-already-running)
+      IGNORE_IF_ALREADY_RUNNING=true
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if pgrep 'nginx' > /dev/null; then
+  echo "nginx already running"
+  if [ "$IGNORE_IF_ALREADY_RUNNING" = false ] ; then
+    echo -e "Did you mean ${YELLOW}dev-nginx start -i${NC} or ${YELLOW}dev-nginx restart${NC}?"
+    exit 1
+  fi
+else
+  echo -e "${YELLOW}Starting nginx. This requires sudo access.${NC}"
+  sudo nginx
+fi
+


### PR DESCRIPTION
## What does this change?
Adds a start script with an option to ignore an already running instance of nginx.

## How can we measure success?
This will be useful when scripting the starting of a service as it can become:

```
dev-nginx start -i
sbt run
```

This helps avoid the situation where you receive an error such as `ERR_CONNECTION_REFUSED` in the browser as you've forgotten to manually start nginx.

## Images
n/a
