### PR TITLE
add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Locates the directory nginx is installed.
 dev-nginx start
 ```
 
-Starts nginx. Will fail if currently running. Add `-i` to ignore if nginx is currently running.
+Starts nginx. Will fail if currently running. Add `-g` to ignore if nginx is currently running.
 
 #### `restart`
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ See [troubleshooting faq](TROUBLESHOOTING.md)
 
 Installing and running dev-nginx will start an [nginx](https://nginx.org/en/) server instance locally on your machine.
 
-This instance will use any `*.conf` files found locally within the directory `/nginx/servers` to generate a virtual server host to proxy requests to localhost. You can locate this directory with the command `dev-nginx locate-nginx`.
+This instance will use any `*.conf` files found locally within the directory `/nginx/servers` to generate a virtual server host to proxy requests to localhost. You can locate this directory with the command `dev-nginx locate`.
 
 Each project config should include http directives for proxy localhost ports and necessary SSL certificates. This is quite repetitive, so `dev-nginx` abstracts it away with the `setup-app` and `setup-cert` commands.
 
@@ -71,10 +71,11 @@ dev-nginx COMMAND <OPTIONS>
 Available commands:
 - add-to-hosts-file
 - link-config
-- locate-nginx
-- restart-nginx
+- locate
+- restart
 - setup-app
 - setup-cert
+- start
 ```
 
 ### Commands
@@ -93,20 +94,27 @@ If it does not already exist, adds an entry to `/etc/hosts` that resolves to `12
 dev-nginx link-config /path/to/site.conf
 ```
 
-Symlink an existing file into nginx configuration. You'll need to restart nginx to activate it (`dev-nginx restart-nginx`).
+Symlink an existing file into nginx configuration. You'll need to restart nginx to activate it (`dev-nginx restart`).
 
-#### `locate-nginx`
+#### `locate`
 
 ```bash
-dev-nginx locate-nginx
+dev-nginx locate
 ```
 
 Locates the directory nginx is installed.
 
-#### `restart-nginx`
+#### `start`
+```bash
+dev-nginx start
+```
+
+Starts nginx. Will fail if currently running. Add `-i` to ignore if nginx is currently running.
+
+#### `restart`
 
 ```bash
-dev-nginx restart-nginx
+dev-nginx restart
 ```
 
 Stops, if running, and starts nginx.

--- a/script/start
+++ b/script/start
@@ -6,12 +6,24 @@ set -e
 YELLOW='\033[1;33m'
 NC='\033[0m' # no colour - reset console colour
 
-IGNORE_IF_ALREADY_RUNNING=false
+GRACEFUL=false
+
+function printHelp() {
+  echo "Starts nginx. Will fail if nginx is already running."
+  echo "  Flags:"
+  echo "    -g | --graceful ignore nginx if it's already running"
+  echo "    -h | --help     print this message"
+  exit 0
+}
 
 while test $# -gt 0; do
   case "$1" in
-    -i|--ignore-if-already-running)
-      IGNORE_IF_ALREADY_RUNNING=true
+    -g|--graceful)
+      GRACEFUL=true
+      shift
+      ;;
+    -h|--help)
+      printHelp
       shift
       ;;
     *)
@@ -21,13 +33,13 @@ while test $# -gt 0; do
 done
 
 if pgrep 'nginx' > /dev/null; then
-  echo "nginx already running"
-  if [ "$IGNORE_IF_ALREADY_RUNNING" = false ] ; then
-    echo -e "Did you mean ${YELLOW}dev-nginx start -i${NC} or ${YELLOW}dev-nginx restart${NC}?"
+  if [ "$GRACEFUL" = true ] ; then
+    exit 0
+  else
+    echo -e "Error: nginx already running. Did you mean ${YELLOW}dev-nginx restart${NC} or ${YELLOW}dev-nginx start -g${NC}?"
     exit 1
   fi
 else
   echo -e "${YELLOW}Starting nginx. This requires sudo access.${NC}"
   sudo nginx
 fi
-

--- a/script/start
+++ b/script/start
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+# colours
+YELLOW='\033[1;33m'
+NC='\033[0m' # no colour - reset console colour
+
+IGNORE_IF_ALREADY_RUNNING=false
+
+while test $# -gt 0; do
+  case "$1" in
+    -i|--ignore-if-already-running)
+      IGNORE_IF_ALREADY_RUNNING=true
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if pgrep 'nginx' > /dev/null; then
+  echo "nginx already running"
+  if [ "$IGNORE_IF_ALREADY_RUNNING" = false ] ; then
+    echo -e "Did you mean ${YELLOW}dev-nginx start -i${NC} or ${YELLOW}dev-nginx restart${NC}?"
+    exit 1
+  fi
+else
+  echo -e "${YELLOW}Starting nginx. This requires sudo access.${NC}"
+  sudo nginx
+fi
+


### PR DESCRIPTION
https://github.com/guardian/dev-nginx/pull/18 take 2.

## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Adds a start script with an option to ignore an already running instance of nginx.

This will be useful when scripting the starting of a service.

Let's say we have the following in the file `script/start`:

```sh
#!/usr/bin/env bash

set -e

sbt run
```

If the service requires an nginx reverse proxy running, we'd need to separately ensure it's running. This PR allows us to further script nginx, `script/start` becomes:

```sh
#!/usr/bin/env bash

set -e

dev-nginx start -g
sbt run
```

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Simplifying the process of starting an application locally.
