### PR TITLE
add  `X-Forwarded-Proto` header

### DIFF
--- a/script/setup-app
+++ b/script/setup-app
@@ -69,6 +69,7 @@ EOS
     proxy_pass http://localhost:#{mapping['port']}#{path};
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $http_host;
     proxy_redirect default;
     proxy_buffering off;


### PR DESCRIPTION
## What does this change?
Play is not treating proxied requests as `secure` if they're missing `X-Forwarded-Proto` (when using Play `trustedProxies` - see https://www.playframework.com/documentation/2.8.x/HTTPServer#Configuring-trusted-proxies)

## How to test
Not sure how to release this project, but I've tested this directly on a .conf file for on https://github.com/guardian/grid

## How can we measure success?
Things don't 403 locally even though they work in AWS.

## Have we considered potential risks?
Can't think of any risks.