### PR TITLE
Remove old TLS version and add new one

### DIFF
--- a/script/setup-app
+++ b/script/setup-app
@@ -84,7 +84,7 @@ EOS
 
   ssl_session_timeout 5m;
 
-  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_protocols TLSv1.2 TLSv1.3;
   ssl_ciphers HIGH:!aNULL:!MD5;
   ssl_prefer_server_ciphers on;
 EOS


### PR DESCRIPTION
## What does this change?

`TLSv1` and `TLSv1.1` are insecure and have been deprecated from most browsers since a long time!
Ideally we should be only using `TLSv1.3` but for compatibility reasons we can keep `TLSv1.2`
 
<img width="1446" alt="Screenshot 2021-12-13 at 17 05 10" src="https://user-images.githubusercontent.com/615085/145856788-1e3052da-cdf4-4fd1-992c-8cfe460053b9.png">
<img width="500" alt="Screenshot 2021-12-13 at 17 06 32" src="https://user-images.githubusercontent.com/615085/145856804-2198fed8-08a2-4a7b-8077-c608f7d33a82.png">
