### PR TITLE
Do not add trailing slash to websocket path

### DIFF
--- a/script/setup-app
+++ b/script/setup-app
@@ -51,8 +51,8 @@ EOS
         if websocket
             file.write <<-EOS
 
-    location #{websocket}/ {
-      proxy_pass http://localhost:#{mapping['port']}#{websocket}/;
+    location #{websocket} {
+      proxy_pass http://localhost:#{mapping['port']}#{websocket};
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";


### PR DESCRIPTION
When using Hot Module Reloading (HMR) with Create React App (i.e. WebPack under the hood), the WebSockets server is listening at `/sockjs-node` for CRA/WebPack v4:

<img width="641" alt="Screenshot 2023-03-20 at 09 55 17" src="https://user-images.githubusercontent.com/5122968/226307727-d29a8289-a75e-48b6-b3e4-63c1a0d8ae0f.png">

and at `/ws` for v5:

<img width="591" alt="Screenshot 2023-03-20 at 10 01 22" src="https://user-images.githubusercontent.com/5122968/226307759-37afb428-aee5-4b26-a767-254562876f42.png">

Since dev-nginx adds a trailing slash to the nginx config, it fails to proxy these through correctly:

<img width="568" alt="Screenshot 2023-03-20 at 10 01 44" src="https://user-images.githubusercontent.com/5122968/226307795-16c69d67-958f-4510-81c8-585eec7d9d0b.png">

Removing the trailing slash fixes the issue:

<img width="694" alt="Screenshot 2023-03-20 at 10 03 07" src="https://user-images.githubusercontent.com/5122968/226307858-78a16e73-0e88-40c4-b055-8cb44788244e.png">

